### PR TITLE
Fix a MethodNotFound error

### DIFF
--- a/Check-PESecurity.ps1
+++ b/Check-PESecurity.ps1
@@ -520,8 +520,9 @@ function EnumerateFiles {
             $NtHeader = [System.Runtime.InteropServices.Marshal]::PtrToStructure($PointerNtHeader, [Type] [PE+_IMAGE_NT_HEADERS32])
         }
         $ARCH = $NtHeader.FileHeader.Machine.toString()
-        $DllCharacteristics = $NtHeader.OptionalHeader.DllCharacteristics.toString().Split(',').Trim()
+        $DllCharacteristics = $NtHeader.OptionalHeader.DllCharacteristics.toString().Split(',')
         foreach($DllCharacteristic in $DllCharacteristics){
+            $DllCharacteristic = $DllCharacteristic.Trim()
             switch($DllCharacteristic){
                 "DYNAMIC_BASE" {$aslr = $true}
                 "NX_COMPAT" {$dep = $true}


### PR DESCRIPTION
Split returns an array, which does not have a Trim method. Instead, run
Trim within the for loop. Caused an error message and false negative
(DEP and ASLR reported false when they were in fact true).