### PR TITLE
Add ARM64 to arch definitions

### DIFF
--- a/Get-PESecurity.psm1
+++ b/Get-PESecurity.psm1
@@ -91,6 +91,7 @@ function Get-PESecurity
       AMD64 = 0x8664 # AMD64 (K8)
       M32R = 0x9041 # M32R little-endian
       CEE = 0xC0EE
+      ARM64 = 0xAA64 # ARM64
     }
 
     $ImageFileCharacteristics = enumerate $Mod PE.IMAGE_FILE_CHARACTERISTICS UInt16 @{


### PR DESCRIPTION
Adding ARM64 arch definition according to https://learn.microsoft.com/en-us/dotnet/api/system.reflection.portableexecutable.machine?view=net-8.0